### PR TITLE
adapted to nassa-schema v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 0.7.0: Adapted checks on softwareDependencies to nassa-schema v0.3.0
 - V 0.6.1: Discarded checks on designDetailsFile field
 - V 0.6.0: Added all the necessary mechanisms to make nassa aware of the NASSA standard versions of modules
 - V 0.5.0: Added a cli subcommand validate

--- a/nassa.cabal
+++ b/nassa.cabal
@@ -1,5 +1,5 @@
 name:                nassa
-version:             0.6.0
+version:             0.7.0
 synopsis:            A package to validate NASSA modules
 description:         NASSA maintains a library of agent-based-modelling algorithms in individual code modules. Each module is defined by a NASSA.yml file. nassa-hs validates these .yml files.
 license:             MIT

--- a/src/NASSA/Types.hs
+++ b/src/NASSA/Types.hs
@@ -35,7 +35,6 @@ data NassaModuleYamlStruct = NassaModuleYamlStruct {
     , _nassaYamlModellingKeywords :: [String]
     , _nassaYamlProgrammingKeywords :: [String]
     , _nassaYamlImplementations :: [Implementation]
-    , _nassaYamlSoftwareDependencies :: [String]
     , _nassaYamlInputs :: Maybe [ModuleInput]
     , _nassaYamlOutputs :: Maybe [ModuleOutput]
     -- , _nassaYamlDocsCheckList :: DocsCheckList
@@ -60,7 +59,6 @@ instance FromJSON NassaModuleYamlStruct where
         <*> v .:  "modellingKeywords"
         <*> v .:  "programmingKeywords"
         <*> v .:  "implementations"
-        <*> v .:  "softwareDependencies"
         <*> v .:? "inputs"
         <*> v .:? "outputs"
         -- <*> v .:  "docsCheckList"
@@ -227,6 +225,7 @@ instance FromJSON DomainKeyword where
 data Implementation = Implementation
     { _implementationLanguage :: ProgrammingLanguage
     , _implementationCodeDir :: FilePath
+    , _nassaYamlSoftwareDependencies :: [String]
     }
     deriving (Show, Eq)
 
@@ -234,6 +233,7 @@ instance FromJSON Implementation where
     parseJSON = withObject "implementations" $ \v -> Implementation
         <$> v .: "language"
         <*> v .: "codeDir"
+        <*> v .:  "softwareDependencies"
 
 data ProgrammingLanguage = 
       LanguageR 

--- a/src/NASSA/Types.hs
+++ b/src/NASSA/Types.hs
@@ -80,7 +80,7 @@ instance FromJSON ModuleID where
 type NassaVersion = Version
 
 validNassaVersions :: [NassaVersion]
-validNassaVersions = map makeVersion [[0,1,0]]
+validNassaVersions = map makeVersion [[0,3,0]]
 
 latestNassaVersion :: NassaVersion
 latestNassaVersion = last validNassaVersions


### PR DESCRIPTION
the softwareDependencies field is now specific for each implementation. This allows us to have a consistent flexibility regarding how many implementations can exist for the same module. I'll be now updating the library NASSA.yml files. 