### PR TITLE
ORCID validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- V 0.8.0: Added validation of the ORCID identifier
 - V 0.7.0: Adapted checks on softwareDependencies to nassa-schema v0.3.0
 - V 0.6.1: Discarded checks on designDetailsFile field
 - V 0.6.0: Added all the necessary mechanisms to make nassa aware of the NASSA standard versions of modules

--- a/nassa.cabal
+++ b/nassa.cabal
@@ -1,5 +1,5 @@
 name:                nassa
-version:             0.7.0
+version:             0.8.0
 synopsis:            A package to validate NASSA modules
 description:         NASSA maintains a library of agent-based-modelling algorithms in individual code modules. Each module is defined by a NASSA.yml file. nassa-hs validates these .yml files.
 license:             MIT


### PR DESCRIPTION
We also added ORCIDs to the Poseidon standard, so I finally came around to implementing the ORCID validation mechanism. Should be correct like this.

When we merge this PR, then the module library will become invalid, because some of the ORCIDs there are only dummies. Here's what the validation gives me with this change:

```
$ nassa validate -d .
nassa v0.8.0 for the NASSA standard v0.3.0

Searching NASSA.yml files...
8 found
Checking NASSA versions...
Loading NASSA.yml files...
Some files were skipped:
/!\ YAML file ./2022-Romanowska-002/NASSA.yml could not be parsed: Aeson exception:
Error in $.contributors[0].orcid: (line 1, column 20):
unexpected end of input
expecting end of input or ORCID is not valid
/!\ YAML file ./2022-Romanowska-001/NASSA.yml could not be parsed: Aeson exception:
Error in $.contributors[0].orcid: (line 1, column 20):
unexpected end of input
expecting end of input or ORCID is not valid
/!\ YAML file ./2021-Romanowska-001/NASSA.yml could not be parsed: Aeson exception:
Error in $.contributors[0].orcid: (line 1, column 20):
unexpected end of input
expecting end of input or ORCID is not valid
/!\ YAML file ./0000-NASSA-001-TEMPLATE/NASSA.yml could not be parsed: Aeson exception:
Error in $.contributors[0].orcid: (line 1, column 20):
unexpected end of input
expecting end of input or ORCID is not valid
***
4 loaded
Validation failed: ERROR
```

I think for the real packages we could just quickly enter correct ORCIDs. For the template we could use good old [Josiah Carberry](https://orcid.org/0000-0002-1825-0097).